### PR TITLE
v0.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 | M5StickC                  | env:m5stack-c                                        |                                                                                                          |
 | M5StickC Plus             | env:m5stack-c-plus                                   |                                                                                                          |
 | M5ATOM Lite/Matrix/Echo/U | env:m5stack-atom                                     |                                                                                                          |
-| M5ATOMS3                  | env:m5stack-atoms3 <br> env:m5stack-atoms3-m5unified | 公式ライブラリを使用<br>[M5Unified](https://github.com/m5stack/M5Unified) を使用。USB CDC On Boot が有効 |
+| M5ATOMS3/Lite             | env:m5stack-atoms3 <br> env:m5stack-atoms3-m5unified | 公式ライブラリを使用<br>[M5Unified](https://github.com/m5stack/M5Unified) を使用。USB CDC On Boot が有効 |
 | M5Stack CoreInk           | env:m5stack-core-ink                                 |                                                                                                          |
 | M5Stack Paper             | env:m5stack-paper                                    |                                                                                                          |
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ upload_port = COM16
 monitor_port = ${env.upload_port}
 ```
 
+※PlatformIO IDE [v3.0.0](https://github.com/platformio/platformio-vscode-ide/releases/tag/v3.0.0)より，ステータスバーからポートの切り替えができるようになりました。
+
 #### 環境名の設定
 
 「Switch PlatformIO Project Environment」（VSCode のステータスバーにある）で機種に合った環境名を設定します。

--- a/platformio.ini
+++ b/platformio.ini
@@ -84,8 +84,7 @@ lib_deps =
     fastled/FastLED
 
 [env:m5stack-atoms3]
-; platform_packages = platformio/framework-arduinoespressif32@^3.20005.220925
-; platform = espressif32@5.2.0
+platform_packages = platformio/tool-esptoolpy@1.40300.0 ; for ATOMS3 Lite
 board = esp32-s3-devkitc-1
 board_build.mcu = esp32s3
 build_flags =


### PR DESCRIPTION
* ATOMS3 Liteに対応
  esptool v4.4だとATOMS3 Liteに書き込みができないので，ATOMS3/Liteの場合は`platform_packages`でesptool v4.3を明示するようにした
* PlatformIO IDE v3.0.0からステータスバーからシリアルポートの変更ができることを追記
