### PR TITLE
Add firmware build workflow

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -1,0 +1,41 @@
+name: Build merged firmware
+
+on:
+  workflow_dispatch:
+    inputs:
+      platformio_env:
+        description: "PlatformIO environment to build"
+        required: true
+        default: '["m5stack-basic"]'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platformio_env: ${{ fromJSON(inputs.platformio_envs) }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Install PlatformIO
+        run: pip install -U platformio
+
+      - name: Clean firmware directory
+        run: rm -rf firmware && mkdir -p firmware
+
+      - name: Build merged firmware
+        run: pio run -e ${{ inputs.platformio_env }} -t firmware
+
+      - name: Upload firmware artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware-${{ matrix.platformio_env }}
+          path: firmware/*_${{ matrix.platformio_env }}_firmware_*.bin
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -148,3 +148,119 @@ lib_deps =
 ### 実機へのアップロード
 
 PlatformIO: Upload（VSCode のステータスバーにある → ボタン）を実行します。
+
+### ファームウェアファイルの生成
+
+この boilerplate には，配布用の merged firmware を生成するための PlatformIO custom target が含まれています。
+
+次のコマンドを実行すると，指定した PlatformIO environment 用のファームウェアファイルを生成できます。
+
+```sh
+pio run -e m5stack-basic -t firmware
+```
+
+VSCode の PlatformIO 拡張機能を使っている場合は、PlatformIO の Project Tasks から対象の environment を選び、**Custom** にある **Generate merged firmware** を実行しても同じファームウェアファイルを生成できます。
+
+これは、次のコマンドを実行するのと同じです。
+
+```sh
+pio run -e <environment> -t firmware
+```
+
+生成されるファームウェアファイルは，デフォルトでは `firmware/` ディレクトリに出力されます。
+
+ファイル名は次の形式になります。
+
+```text
+プロジェクト名_env名_firmware_バージョン.bin
+```
+
+例：
+
+```text
+my_project_m5stack-basic_firmware_0.1.0.bin
+```
+
+プロジェクト名を明示したい場合は，`platformio.ini` の `[env]` セクションで `custom_firmware_name` を指定します。指定しない場合は，プロジェクトディレクトリ名が使用されます。
+
+```ini
+[env]
+custom_firmware_name = my_project
+```
+
+ファームウェアのバージョンは，次の優先順位で決まります。
+
+1. `custom_firmware_version`
+2. `custom_firmware_version_file` と `custom_firmware_version_regex` によるファイルからの抽出
+3. GitHub Actions 実行時の Git tag 名
+4. `dev`
+
+バージョンを直接指定する場合は，次のように設定します。
+
+```ini
+[env]
+custom_firmware_version = 0.1.0
+```
+
+ファイルから正規表現でバージョンを抽出する場合は，次のように設定します。
+
+```ini
+[env]
+custom_firmware_version_file = main.cpp
+custom_firmware_version_regex = "v(\d+\.\d+\.\d+)"
+```
+
+`custom_firmware_version` を指定した場合は，ファイルから抽出する設定よりも優先されます。
+
+### GitHub Actions でファームウェアを生成する
+
+この boilerplate には，GitHub 上でファームウェアをビルドするための GitHub Actions workflow も含まれています。
+
+この workflow は，boilerplate 本体のファームウェアを配布するためというより，この boilerplate から作成された派生プロジェクトが，自分のプロジェクト用ファームウェアを GitHub 上で生成・配布しやすくするためのものです。
+
+使い方は次のとおりです。
+
+1. GitHub の **Actions** タブを開く
+2. **Build merged firmware** workflow を選ぶ
+3. `platformio_envs` にビルドしたい PlatformIO environment 名を JSON 配列で指定する
+4. workflow を実行する
+5. 実行結果から生成された artifact をダウンロードする
+
+たとえば，`m5stack-basic` と `m5stack-atom-matrix` のファームウェアを生成する場合は，次のように指定します。
+
+```json
+["m5stack-basic","m5stack-atom-matrix"]
+```
+
+この場合，GitHub Actions 上で次のようなコマンドが実行されます。
+
+```sh
+pio run -e m5stack-basic -t firmware
+pio run -e m5stack-atom-matrix -t firmware
+```
+
+生成された `.bin` ファイルは，environment ごとに artifact としてアップロードされます。
+
+たとえば `m5stack-basic` の場合，artifact 名は次のようになります。
+
+```text
+firmware-m5stack-basic
+```
+
+artifact をダウンロードすると，その中に次のようなファームウェアファイルが含まれます。
+
+```text
+my_project_m5stack-basic_firmware_0.1.0.bin
+```
+
+派生プロジェクトで標準的にビルドしたい environment が決まっている場合は，`.github/workflows/build-firmware.yml` の `platformio_envs` の `default` を変更してください。
+
+```yaml
+default: '["m5stack-basic"]'
+```
+
+複数の environment を標準にしたい場合は，次のように指定できます。
+
+```yaml
+default: '["m5stack-basic","m5stack-atom-matrix"]'
+```

--- a/README_en_US.md
+++ b/README_en_US.md
@@ -146,3 +146,119 @@ Note: When using `SD.h` or `SPIFFS.h` with M5Unified, make sure to include them 
 ### Upload to Devices
 
 Execute "PlatformIO: Upload" by clicking the right arrow icon located in the VSCode status bar.
+
+### Generating firmware files
+
+This boilerplate includes a PlatformIO custom target for generating a merged firmware image for distribution.
+
+Run the following command to generate firmware for a specific PlatformIO environment.
+
+```sh
+pio run -e m5stack-basic -t firmware
+```
+
+If you are using the PlatformIO extension for VSCode, you can also generate the same firmware file from the PlatformIO Project Tasks view. Select the target environment, then run **Custom** > **Generate merged firmware**.
+
+This is equivalent to running:
+
+```sh
+pio run -e <environment> -t firmware
+```
+
+The generated firmware file is written to the `firmware/` directory by default.
+
+The firmware filename uses the following format:
+
+```text
+project_name_environment_name_firmware_version.bin
+```
+
+Example:
+
+```text
+my_project_m5stack-basic_firmware_0.1.0.bin
+```
+
+To specify the project name used in the firmware filename, set `custom_firmware_name` in the `[env]` section of `platformio.ini`. If omitted, the project directory name is used.
+
+```ini
+[env]
+custom_firmware_name = my_project
+```
+
+The firmware version is resolved in the following order:
+
+1. `custom_firmware_version`
+2. `custom_firmware_version_file` + `custom_firmware_version_regex`
+3. Git tag name when running on GitHub Actions
+4. `dev`
+
+To specify the version directly, use:
+
+```ini
+[env]
+custom_firmware_version = 0.1.0
+```
+
+To extract the version from a file using a regular expression, use:
+
+```ini
+[env]
+custom_firmware_version_file = main.cpp
+custom_firmware_version_regex = "v(\d+\.\d+\.\d+)"
+```
+
+When `custom_firmware_version` is specified, it takes priority over the version extracted from a file.
+
+### Building firmware with GitHub Actions
+
+This boilerplate also includes a GitHub Actions workflow for building firmware on GitHub.
+
+The workflow is mainly intended for projects created from this boilerplate. It allows derived projects to build and distribute their own firmware artifacts on GitHub without requiring users to install PlatformIO locally.
+
+To use it:
+
+1. Open the **Actions** tab on GitHub.
+2. Select the **Build merged firmware** workflow.
+3. Set `platformio_envs` to the PlatformIO environments you want to build, using a JSON array.
+4. Run the workflow.
+5. Download the generated artifacts from the workflow result.
+
+For example, to build firmware for `m5stack-basic` and `m5stack-atom-matrix`, enter:
+
+```json
+["m5stack-basic","m5stack-atom-matrix"]
+```
+
+The workflow will run commands like:
+
+```sh
+pio run -e m5stack-basic -t firmware
+pio run -e m5stack-atom-matrix -t firmware
+```
+
+The generated `.bin` files are uploaded as artifacts for each environment.
+
+For example, the artifact name for `m5stack-basic` will be:
+
+```text
+firmware-m5stack-basic
+```
+
+After downloading the artifact, it will contain a firmware file such as:
+
+```text
+my_project_m5stack-basic_firmware_0.1.0.bin
+```
+
+If a derived project has specific environments that should be built by default, edit `.github/workflows/build-firmware.yml` and change the `default` value of `platformio_envs`.
+
+```yaml
+default: '["m5stack-basic"]'
+```
+
+To build multiple environments by default, use:
+
+```yaml
+default: '["m5stack-basic","m5stack-atom-matrix"]'
+```

--- a/platformio.ini
+++ b/platformio.ini
@@ -62,6 +62,21 @@ lib_ldf_mode = deep
 ; upload_port = COM16
 ; monitor_port = ${env.upload_port}
 
+extra_scripts = post:scripts/generate_merged_firmware.py
+; Optional: Project name used in the firmware filename.
+; If omitted, the project directory name is used.
+; custom_firmware_name = my_project
+
+; Optional: Firmware version used in the firmware filename.
+; custom_firmware_version has priority when specified.
+; Otherwise, the version can be extracted from a file using regex.
+; If neither is specified, the GitHub tag name is used when available, or "dev".
+;
+; custom_firmware_version = 0.1.0
+; custom_firmware_version_file = main.cpp
+; custom_firmware_version_regex = "v(\d+\.\d+\.\d+)"
+custom_firmware_dir = firmware
+
 [build-target]
 extends = release
 ; extends = debug

--- a/scripts/generate_merged_firmware.py
+++ b/scripts/generate_merged_firmware.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import subprocess
+from typing import Any
+
+from SCons.Script import DefaultEnvironment  # type: ignore[import-untyped]
+
+env: Any = DefaultEnvironment()
+
+
+def get_project_option(name, default=None):
+    try:
+        value = env.GetProjectOption(name)
+    except Exception:
+        return default
+
+    if value is None:
+        return default
+
+    if isinstance(value, str):
+        value = env.subst(value).strip()
+        if value == "":
+            return default
+
+    return value
+
+
+def split_list(value):
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    return [item.strip() for item in re.split(r"[,\s]+", str(value)) if item.strip()]
+
+
+def sanitize_filename_part(value):
+    return re.sub(r"[^A-Za-z0-9._-]+", "_", str(value)).strip("_")
+
+
+def sanitize_project_name(value):
+    return sanitize_filename_part(str(value).replace("-", "_"))
+
+
+def normalize_version(value):
+    value = str(value).strip()
+    return value[1:] if value.startswith("v") else value
+
+
+def read_version_from_file(path, pattern):
+    with open(path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    match = re.search(pattern, content)
+    if not match:
+        raise RuntimeError(f"Version is not found in {path}")
+
+    return normalize_version(match.group(1))
+
+
+def resolve_version():
+    explicit_version = get_project_option("custom_firmware_version")
+    if explicit_version:
+        return normalize_version(explicit_version)
+
+    version_file = get_project_option("custom_firmware_version_file")
+    if version_file:
+        pattern = get_project_option(
+            "custom_firmware_version_regex",
+            r"v?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)",
+        )
+
+        project_dir = env.subst("$PROJECT_DIR")
+        src_dir = env.subst("$PROJECT_SRC_DIR")
+
+        candidates = []
+        if os.path.isabs(version_file):
+            candidates.append(version_file)
+        else:
+            candidates.append(os.path.join(src_dir, version_file))
+            candidates.append(os.path.join(project_dir, version_file))
+
+        for candidate in candidates:
+            if os.path.exists(candidate):
+                return read_version_from_file(candidate, pattern)
+
+        raise RuntimeError(f"Version file is not found: {version_file}")
+
+    github_ref_name = os.environ.get("GITHUB_REF_NAME", "")
+    match = re.match(r"^v?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)$", github_ref_name)
+    if match:
+        return normalize_version(match.group(1))
+
+    return "dev"
+
+
+def resolve_chip():
+    chip = get_project_option("custom_firmware_chip")
+    if chip:
+        return chip.lower().replace("-", "")
+
+    chip = get_project_option("board_build.mcu")
+    if chip:
+        return chip.lower().replace("-", "")
+
+    board_config = env.BoardConfig()
+    chip = board_config.get("build.mcu", None)
+    if chip:
+        return str(chip).lower().replace("-", "")
+
+    raise RuntimeError(
+        "Could not determine chip type. "
+        "Please set custom_firmware_chip, for example: custom_firmware_chip = esp32s3"
+    )
+
+
+def generate_merged_firmware(target, source, env):
+    project_dir = env.subst("$PROJECT_DIR")
+    build_dir = env.subst("$BUILD_DIR")
+    pioenv = env.subst("$PIOENV")
+    progname = env.subst("$PROGNAME")
+
+    firmware_dir = get_project_option("custom_firmware_dir", "firmware")
+    if not os.path.isabs(firmware_dir):
+        firmware_dir = os.path.join(project_dir, firmware_dir)
+    os.makedirs(firmware_dir, exist_ok=True)
+
+    firmware_name = get_project_option(
+        "custom_firmware_name",
+        os.path.basename(project_dir),
+    )
+    firmware_target = get_project_option("custom_firmware_target")
+    if firmware_target is None:
+        firmware_target = env.subst("$PIOENV")
+    firmware_suffix = get_project_option("custom_firmware_suffix", "bin")
+    firmware_version = resolve_version()
+    firmware_env = get_project_option("custom_firmware_env")
+    if firmware_env is None:
+        firmware_env = pioenv
+    output_filename = "{name}_{env}_firmware_{version}.{suffix}".format(
+        name=sanitize_project_name(firmware_name),
+        env=sanitize_filename_part(firmware_env),
+        version=sanitize_filename_part(firmware_version),
+        suffix=sanitize_filename_part(firmware_suffix),
+    )
+    output_path = os.path.join(firmware_dir, output_filename)
+
+    app_bin = os.path.join(build_dir, f"{progname}.{firmware_suffix}")
+
+    if not os.path.exists(app_bin):
+        raise RuntimeError(f"Application binary is not found: {app_bin}")
+
+    extra_images = env.get("FLASH_EXTRA_IMAGES", [])
+    if not extra_images:
+        raise RuntimeError("FLASH_EXTRA_IMAGES is empty. Cannot build merged firmware.")
+
+    chip = resolve_chip()
+
+    cmd = [
+        env.subst("$PYTHONEXE"),
+        env.subst("$UPLOADER"),
+        "--chip",
+        chip,
+        "merge_bin",
+        "-o",
+        output_path,
+    ]
+
+    flash_mode = get_project_option("custom_firmware_flash_mode")
+    flash_freq = get_project_option("custom_firmware_flash_freq")
+    flash_size = get_project_option("custom_firmware_flash_size")
+
+    if flash_mode:
+        cmd.extend(["--flash-mode", flash_mode])
+    if flash_freq:
+        cmd.extend(["--flash-freq", flash_freq])
+    if flash_size:
+        cmd.extend(["--flash-size", flash_size])
+
+    for address, image in extra_images:
+        cmd.extend([str(address), env.subst(image)])
+
+    cmd.extend([env.subst("$ESP32_APP_OFFSET"), app_bin])
+
+    print("Generating merged firmware:")
+    print(" ".join(shlex.quote(part) for part in cmd))
+
+    subprocess.check_call(cmd)
+
+    print(f"Merged firmware generated: {output_path}")
+
+
+firmware_suffix = get_project_option("custom_firmware_suffix", "bin")
+app_bin = os.path.join("$BUILD_DIR", f"${{PROGNAME}}.{firmware_suffix}")
+
+dependencies = [app_bin]
+dependencies.extend(split_list(get_project_option("custom_firmware_dependencies")))
+
+env.AddCustomTarget(
+    name="firmware",
+    dependencies=dependencies,
+    actions=[generate_merged_firmware],
+    title="Generate merged firmware",
+    description="Generate a single merged firmware image for distribution",
+)


### PR DESCRIPTION
## Summary

This adds an optional firmware build workflow for projects created from this boilerplate.

- Add a PlatformIO custom target to generate a single merged firmware image
- Add a manually triggered GitHub Actions workflow
- Support one or more PlatformIO environments via `workflow_dispatch`
- Upload generated firmware images as downloadable artifacts
- Document how derived projects can customize the firmware name and version

This is mainly intended for projects created from this boilerplate, so they can provide downloadable firmware artifacts without requiring users to install PlatformIO locally.

Refs #37